### PR TITLE
feat: allow outputting the workdir(s) for one or more Dockerfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Commands:
   dump        Dump parsed Dockerfile(s).
   fmt         Format the Dockerfile(s).
   maintainer  List the maintainer for the Dockerfile(s).
+  workdir     List the workdirs for the Dockerfile(s).
   version     Show the version information.
 ```
 
@@ -153,4 +154,13 @@ Christian Koep <christian.koep@ksldkfj.de>      11
 Justin Garrison <justinleegarrison@hskdl.com>   2
 Daniel Romero <infoslack@jjskl.com>             1
 Cris G c@skdlemfhtj.com                         1
+```
+
+### Workdir inspection
+
+```console
+$ dockfmt workdir */Dockerfile */*/Dockerfile
+WORKDIR   COUNT
+/srv      3
+/app      1
 ```

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 		&dumpCommand{},
 		&formatCommand{},
 		&maintainerCommand{},
+		&workdirCommand{},
 	}
 
 	// Set the before function.

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		}
 
 		if p.FlagSet.NArg() < 1 {
-			return errors.New("Please pass in Dockerfile(s)")
+			return errors.New("please pass in Dockerfile(s)")
 		}
 
 		return nil
@@ -83,7 +83,7 @@ func rank(images map[string]int) pairList {
 
 func labelSearch(search string, n *parser.Node, a map[string]int) map[string]int {
 	if n.Value == "label" {
-		if n.Next != nil && strings.ToLower(n.Next.Value) == strings.ToLower(search) {
+		if n.Next != nil && strings.EqualFold(strings.ToLower(n.Next.Value), strings.ToLower(search)) {
 			i := strings.Trim(n.Next.Next.Value, "\"")
 			if v, ok := a[i]; ok {
 				a[i] = v + 1

--- a/workdir.go
+++ b/workdir.go
@@ -21,14 +21,10 @@ func (cmd *workdirCommand) Hidden() bool      { return false }
 func (cmd *workdirCommand) Register(fs *flag.FlagSet) {
 	fs.BoolVar(&cmd.noRank, "no-rank", false, "turn off ranking of WORKDIRs")
 	fs.BoolVar(&cmd.noRank, "N", false, "turn off ranking of WORKDIRs")
-
-	fs.BoolVar(&cmd.skipHeader, "skip-header", false, "skip printing headers")
-	fs.BoolVar(&cmd.skipHeader, "S", false, "skip printing headers")
 }
 
 type workdirCommand struct {
-	noRank     bool
-	skipHeader bool
+	noRank bool
 }
 
 func (cmd *workdirCommand) Run(ctx context.Context, args []string) error {
@@ -48,19 +44,15 @@ func (cmd *workdirCommand) Run(ctx context.Context, args []string) error {
 	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
 
 	if cmd.noRank {
-		if !cmd.skipHeader {
-			// print header
-			fmt.Fprintln(w, "WORKDIR")
-		}
+		// print header
+		fmt.Fprintln(w, "WORKDIR")
 
 		for workdir := range workdirs {
 			fmt.Fprintf(w, "%s\n", workdir)
 		}
 	} else {
-		if !cmd.skipHeader {
-			// print header
-			fmt.Fprintln(w, "WORKDIR\tCOUNT")
-		}
+		// print header
+		fmt.Fprintln(w, "WORKDIR\tCOUNT")
 
 		pl := rank(workdirs)
 		for _, p := range pl {

--- a/workdir.go
+++ b/workdir.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/moby/buildkit/frontend/dockerfile/parser"
+)
+
+const workdirHelp = `List the workdirs for the Dockerfile(s).`
+
+func (cmd *workdirCommand) Name() string      { return "workdir" }
+func (cmd *workdirCommand) Args() string      { return "[OPTIONS] DOCKERFILE [DOCKERFILE...]" }
+func (cmd *workdirCommand) ShortHelp() string { return workdirHelp }
+func (cmd *workdirCommand) LongHelp() string  { return workdirHelp }
+func (cmd *workdirCommand) Hidden() bool      { return false }
+
+func (cmd *workdirCommand) Register(fs *flag.FlagSet) {
+	fs.BoolVar(&cmd.noRank, "no-rank", false, "turn off ranking of WORKDIRs")
+	fs.BoolVar(&cmd.noRank, "N", false, "turn off ranking of WORKDIRs")
+
+	fs.BoolVar(&cmd.skipHeader, "skip-header", false, "skip printing headers")
+	fs.BoolVar(&cmd.skipHeader, "S", false, "skip printing headers")
+}
+
+type workdirCommand struct {
+	noRank     bool
+	skipHeader bool
+}
+
+func (cmd *workdirCommand) Run(ctx context.Context, args []string) error {
+	workdirs := map[string]int{}
+
+	err := forFile(args, func(f string, nodes []*parser.Node) error {
+		for _, n := range nodes {
+			workdirs = nodeSearch("workdir", n, workdirs)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// setup the tab writer
+	w := tabwriter.NewWriter(os.Stdout, 20, 1, 3, ' ', 0)
+
+	if cmd.noRank {
+		if !cmd.skipHeader {
+			// print header
+			fmt.Fprintln(w, "WORKDIR")
+		}
+
+		for workdir := range workdirs {
+			fmt.Fprintf(w, "%s\n", workdir)
+		}
+	} else {
+		if !cmd.skipHeader {
+			// print header
+			fmt.Fprintln(w, "WORKDIR\tCOUNT")
+		}
+
+		pl := rank(workdirs)
+		for _, p := range pl {
+			fmt.Fprintf(w, "%s\t%d\n", p.Key, p.Value)
+		}
+	}
+
+	w.Flush()
+	return nil
+}


### PR DESCRIPTION
This command is useful in inspection of Dockerfiles, and can be used to intelligently push/pull built files from a docker image. It also allows disabling of ranking, such that the the workdirs are output in order of appearance.

For instance, if a build tool expects to pull a config file from a container and has access to the respective Dockerfile, it can do something like:

```shell
# get the workdir and
WORKDIR=$(dockfmt workdir --no-rank --skip-header path/to/Dockerfile | tail -n1)
[[ -z "$WORKDIR" ]] && WORKDIR="/app"
docker cp "container-name:$WORKDIR/nginx.conf.template" nginx.conf || true
```

In this way, we can pull a file from a container at the best path possible - either a specified WORKDIR or a sane default.

As an aside, I would be using this functionality for dokku/dokku#3263, to pull all sorts of config files from built images for the purposes of orchestrating the containers.