### PR TITLE
update install via go instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For installation instructions from binaries please visit the [Releases Page](htt
 #### Via Go
 
 ```console
-$ go get github.com/jessfraz/dockfmt
+$ go install github.com/jessfraz/dockfmt@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go get` isn't supported after go version 1.16